### PR TITLE
Add vline option to Plot_line and update version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/Laplusdestiny/plotly_extend_wrapper?logo=github)](https://github.com/Laplusdestiny/plotly_extend_wrapper/releases)
 [![PyPI - Version](https://img.shields.io/pypi/v/plotly_extend_wrapper?logo=pypi)](https://pypi.org/project/plotly-extend-wrapper/)
 
-
 Extended Python library for Plotly
 
 You can make plot simply
@@ -18,17 +17,8 @@ You can make plot simply
 - pandas >= 2.2.0
 - scipy >= 1.12.0
 
-## Graph
-
-- Pie (`wrapper.Plot_pie`)
-- Sunburst (`wrapper.Plot_sunburst`)
-- Bubble (`wrapper.Plot_bubble_chart`)
-- Line with secondary y-axis (`wrapper.Plot_line`)
-- Bubble with linear line (`wrapper.Plot_bubble_with_line`)
-- Surface (`wrapper.Plot_surface`)
-
-
 ## Issue
+
 If there are some bugs, please make issue to tell me!
 
 [![GitHub issues](https://img.shields.io/github/issues/Laplusdestiny/plotly_extend_wrapper?logo=github)](https://github.com/Laplusdestiny/plotly_extend_wrapper/issues)

--- a/plotly_extend_wrapper/__init__.py
+++ b/plotly_extend_wrapper/__init__.py
@@ -2,4 +2,4 @@ from plotly_extend_wrapper.wrapper import *
 from plotly_extend_wrapper.updater import *
 from plotly_extend_wrapper.common import *
 
-__version__ = "1.1.0"
+__version__ = "1.3.0"

--- a/plotly_extend_wrapper/wrapper.py
+++ b/plotly_extend_wrapper/wrapper.py
@@ -198,6 +198,7 @@ def Plot_line(
     save_html_path=None,
     vspan=None,
     vspan_color_randomize=False,
+    vline=None,
     sort_column=True,
     sort_x=True,
     opacity=0.2,
@@ -300,6 +301,13 @@ def Plot_line(
                 layer="below",
                 line_width=0,
             )
+
+    if vline is not None:
+        if not isinstance(vline, list):
+            vline = [vline]
+
+        for v in vline:
+            subfig.add_vline(x=v)
 
     if save_html_path is not None:
         output_p = check_directory(save_html_path)

--- a/plotly_extend_wrapper/wrapper.py
+++ b/plotly_extend_wrapper/wrapper.py
@@ -199,6 +199,7 @@ def Plot_line(
     vspan=None,
     vspan_color_randomize=False,
     vline=None,
+    vline_color=None,
     sort_column=True,
     sort_x=True,
     opacity=0.2,
@@ -229,6 +230,10 @@ def Plot_line(
         Tuple list for filling color in specify period , by default None
     vspan_color_randomize : bool, optional
         If True, choose random color, by default False
+    vline : list, optional
+        List of timestamp to add vertical line, by default None
+    vline_color : str, optional
+        Color of vertical line, by default None
     sort_column: boolean, optional
         If True, sort y column list
     sort_x: boolean, optional
@@ -306,8 +311,11 @@ def Plot_line(
         if not isinstance(vline, list):
             vline = [vline]
 
+        if vline_color is None:
+            vline_color = pick_color()
+
         for v in vline:
-            subfig.add_vline(x=v)
+            subfig.add_vline(x=v, line_color=vline_color)
 
     if save_html_path is not None:
         output_p = check_directory(save_html_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plotly-extend-wrapper"
-version = "1.2.0"
+version = "1.3.0"
 authors = [{ name = "Laplusdestiny", email = "prayonshootingstars@gmail.com" }]
 dependencies = [
     "plotly>=5.12.0",

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -81,6 +81,42 @@ def test_Line():
     assert isinstance(plot, go.Figure)
 
 
+def test_LineVline():
+    data = MakeTimeSeriesData()
+
+    plot = Plot_line(
+        data,
+        x="timestamp",
+        y=["y1"],
+        secondary_y=["y2"],
+        xtitle="timestamp",
+        ytitle="value",
+        secondary_ytitle="value2",
+        save_html_path="line.html",
+        vline=["2024-01-01 06:00:00"]
+    )
+
+    assert isinstance(plot, go.Figure)
+
+
+def test_LineVlineinstr():
+    data = MakeTimeSeriesData()
+
+    plot = Plot_line(
+        data,
+        x="timestamp",
+        y=["y1"],
+        secondary_y=["y2"],
+        xtitle="timestamp",
+        ytitle="value",
+        secondary_ytitle="value2",
+        save_html_path="line.html",
+        vline="2024-01-01 06:00:00"
+    )
+
+    assert isinstance(plot, go.Figure)
+
+
 def test_LinewithVspan():
     data = MakeTimeSeriesData()
 


### PR DESCRIPTION
Introduce a new vline option for the Plot_line function to allow vertical lines in plots. Update the version to 1.3.0 and remove unnecessary sections from the README.